### PR TITLE
Add links to GitHub repos on user dashboard page

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -8,7 +8,7 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def create
-    @tutorial = Tutorial.create(tutorial_params)
+    @tutorial = Tutorial.new(new_tutorial_params)
 
     if @tutorial.save
       redirect_to tutorial_path(@tutorial.id),
@@ -21,7 +21,7 @@ class Admin::TutorialsController < Admin::BaseController
 
   def update
     tutorial = Tutorial.find(params[:id])
-    if tutorial.update(tutorial_params)
+    if tutorial.update(update_tutorial_params)
       flash[:success] = "#{tutorial.title} tagged!"
     end
     redirect_to edit_admin_tutorial_path(tutorial)
@@ -29,7 +29,11 @@ class Admin::TutorialsController < Admin::BaseController
 
   private
 
-  def tutorial_params
-    params.require(:tutorial).permit(:tag_list, :title, :description, :thumbnail)
+  def update_tutorial_params
+    params.require(:tutorial).permit(:tag_list)
+  end
+
+  def new_tutorial_params
+    params.require(:tutorial).permit(:title, :description, :thumbnail)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def show
+    @github_facade = GithubFacade.new
   end
 
   def new

--- a/app/facades/github_facade.rb
+++ b/app/facades/github_facade.rb
@@ -1,0 +1,18 @@
+class GithubFacade
+
+  def repos
+    service = GithubService.new
+    raw_repos_data = service.get_user_repos
+
+    repos = []
+
+    raw_repos_data.each do |repo_data|
+      repos << Repo.new(repo_data) if repo_data[:owner][:id] == 46035439 # Change to specific username
+      break if repos.length == 5
+    end
+
+    repos
+  end
+
+
+end

--- a/app/models/poros/repo.rb
+++ b/app/models/poros/repo.rb
@@ -1,0 +1,8 @@
+class Repo
+  attr_reader :name, :url
+
+  def initialize(repo_data)
+    @name = repo_data[:name]
+    @url = repo_data[:html_url]
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,7 @@ class User < ApplicationRecord
   has_many :videos, through: :user_videos
 
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password
-  validates_presence_of :first_name
+  validates_presence_of :password, :first_name, :last_name
   enum role: [:default, :admin]
   has_secure_password
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,0 +1,24 @@
+class GithubService
+  def get_user_repos
+    response = fetch_data('/user/repos')
+    parse_data(response)
+  end
+
+
+  private
+
+  def parse_data(response)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def fetch_data(url)
+    conn.get(url)
+  end
+
+  def conn
+    Faraday.new(url: 'https://api.github.com') do |f|
+      f.adapter Faraday.default_adapter
+      f.params[:access_token] = ENV['GITHUB_ACCESS_TOKEN']
+    end
+  end
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,16 @@
     <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>
     <li> <%= current_user.email%> </li>
   </ul>
-  <section>
+  <article>
     <h1>Bookmarked Segments</h1>
-  </section>
+  </article>
+
+  <article class="github-repos">
+    <h1>GitHub Repositories</h1>
+    <ul>
+      <% @github_facade.repos.each do |repo| %>
+        <li><%= link_to repo.name, repo.url %></li>
+      <% end %>
+    </ul>
+  </article>
 </section>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,8 @@ module PersonalProject
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Autoload subdirectory of POROS in the models directory
+    config.autoload_paths += Dir[Rails.root.join('app', 'models', 'poros')]
   end
 end

--- a/spec/features/admin/edit_tutorial_spec.rb
+++ b/spec/features/admin/edit_tutorial_spec.rb
@@ -4,22 +4,24 @@ describe 'An Admin can edit a tutorial' do
   let(:tutorial) { create(:tutorial) }
   let(:admin)    { create(:admin) }
 
-  scenario 'by adding a video', :js, :vcr do
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+  scenario 'by adding a video', :js do
+    VCR.use_cassette('new_youtube_video') do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
-    visit edit_admin_tutorial_path(tutorial)
+      visit edit_admin_tutorial_path(tutorial)
 
-    click_link 'Add Video'
+      click_link 'Add Video'
 
-    fill_in 'video[title]', with: 'How to tie your shoes.'
-    fill_in 'video[description]', with: 'Over, under, around and through, Meet Mr. Bunny Rabbit, pull and through.'
-    fill_in 'video[video_id]', with: 'J7ikFUlkP_k'
-    click_button 'Create Video'
+      fill_in 'video[title]', with: 'How to tie your shoes.'
+      fill_in 'video[description]', with: 'Over, under, around and through, Meet Mr. Bunny Rabbit, pull and through.'
+      fill_in 'video[video_id]', with: 'J7ikFUlkP_k'
+      click_button 'Create Video'
 
-    expect(current_path).to eq(edit_admin_tutorial_path(tutorial))
+      expect(current_path).to eq(edit_admin_tutorial_path(tutorial))
 
-    within(first('.video')) do
-      expect(page).to have_content('How to tie your shoes.')
+      within(first('.video')) do
+        expect(page).to have_content('How to tie your shoes.')
+      end
     end
   end
 end

--- a/spec/features/admin/new_tutorial_spec.rb
+++ b/spec/features/admin/new_tutorial_spec.rb
@@ -1,17 +1,9 @@
 require 'rails_helper'
 
-# When I visit '/admin/tutorials/new'
-# And I fill in 'title' with a meaningful name
-# And I fill in 'description' with a some content
-# And I fill in 'thumbnail' with a valid YouTube thumbnail
-# And I click on 'Save'
-# Then I should be on '/tutorials/{NEW_TUTORIAL_ID}'
-# And I should see a flash message that says "Successfully created tutorial."
-
 describe 'As an Admin.' do
   let(:admin)    { create(:admin) }
 
-  it 'Can create a new tutorial with a video' do
+  it 'Can create a new tutorial without a video' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit new_admin_tutorial_path

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -5,37 +5,41 @@ RSpec.describe 'User show page', type: :feature do
     @users = [create(:user), create(:admin)]
   end
 
-  it 'can see account details', :vcr do
-    @users.each do |user|
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  it 'can see account details' do
+    VCR.use_cassette('github_user_repos') do
+      @users.each do |user|
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-      visit dashboard_path
+        visit dashboard_path
 
-      expect(page).to have_content("#{user.first_name} #{user.last_name}")
-      expect(page).to have_content(user.email)
+        expect(page).to have_content("#{user.first_name} #{user.last_name}")
+        expect(page).to have_content(user.email)
+      end
     end
   end
 
-  it 'can see links to five of my github repos', :vcr do
-    @users.each do |user|
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  it 'can see links to five of my github repos' do
+    VCR.use_cassette('github_user_repos') do
+      @users.each do |user|
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-      visit dashboard_path
+        visit dashboard_path
 
-      repo_names = [
-        'activerecord-obstacle-course',
-        'advent_of_code',
-        'apartments_1908',
-        'apollo_14',
-        'B2_mid_mod_1908'
-      ]
+        repo_names = [
+          'activerecord-obstacle-course',
+          'advent_of_code',
+          'apartments_1908',
+          'apollo_14',
+          'B2_mid_mod_1908'
+        ]
 
-      within '.github-repos' do
-        repo_names.each do |repo_name|
-          expect(page).to have_selector(
-            "a[href='https://github.com/johnktravers/#{repo_name}']",
-            text: repo_name
-          )
+        within '.github-repos' do
+          repo_names.each do |repo_name|
+            expect(page).to have_selector(
+              "a[href='https://github.com/johnktravers/#{repo_name}']",
+              text: repo_name
+            )
+          end
         end
       end
     end

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'User show page', type: :feature do
+  before :each do
+    @users = [create(:user), create(:admin)]
+  end
+
+  it 'can see account details' do
+    @users.each do |user|
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit dashboard_path
+
+      expect(page).to have_content("#{user.first_name} #{user.last_name}")
+      expect(page).to have_content(user.email)
+    end
+  end
+
+  it 'can see links to five of my github repos', :vcr do
+    @users.each do |user|
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit dashboard_path
+
+      repo_names = [
+        'activerecord-obstacle-course',
+        'advent_of_code',
+        'apartments_1908',
+        'apollo_14',
+        'B2_mid_mod_1908'
+      ]
+
+      within '.github-repos' do
+        repo_names.each do |repo_name|
+          expect(page).to have_selector(
+            "a[href='https://github.com/johnktravers/#{repo_name}']",
+            text: repo_name
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'User show page', type: :feature do
     @users = [create(:user), create(:admin)]
   end
 
-  it 'can see account details' do
+  it 'can see account details', :vcr do
     @users.each do |user|
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 

--- a/spec/features/user/user_can_log_in_and_out_spec.rb
+++ b/spec/features/user/user_can_log_in_and_out_spec.rb
@@ -2,44 +2,48 @@ require 'rails_helper'
 
 describe 'User' do
   it 'user can sign in' do
-    user = create(:user)
+    VCR.use_cassette('github_user_repos') do
+      user = create(:user)
 
-    visit '/'
+      visit '/'
 
-    click_link 'Sign In'
+      click_link 'Sign In'
 
-    expect(current_path).to eq(login_path)
+      expect(current_path).to eq(login_path)
 
-    fill_in 'session[email]', with: user.email
-    fill_in 'session[password]', with: user.password
+      fill_in 'session[email]', with: user.email
+      fill_in 'session[password]', with: user.password
 
-    click_button 'Log In'
+      click_button 'Log In'
 
-    expect(current_path).to eq(dashboard_path)
-    expect(page).to have_content(user.email)
-    expect(page).to have_content(user.first_name)
-    expect(page).to have_content(user.last_name)
+      expect(current_path).to eq(dashboard_path)
+      expect(page).to have_content(user.email)
+      expect(page).to have_content(user.first_name)
+      expect(page).to have_content(user.last_name)
+    end
   end
 
   it 'can log out', :js do
-    user = create(:user)
+    VCR.use_cassette('github_user_repos') do
+      user = create(:user)
 
-    visit login_path
+      visit login_path
 
-    fill_in'session[email]', with: user.email
-    fill_in'session[password]', with: user.password
+      fill_in'session[email]', with: user.email
+      fill_in'session[password]', with: user.password
 
-    click_button 'Log In'
+      click_button 'Log In'
 
-    click_link 'Profile'
+      click_link 'Profile'
 
-    expect(current_path).to eq(dashboard_path)
+      expect(current_path).to eq(dashboard_path)
 
-    click_button 'Log Out'
+      click_button 'Log Out'
 
-    expect(current_path).to eq(root_path)
-    expect(page).to_not have_content(user.first_name)
-    expect(page).to have_content('SIGN IN')
+      expect(current_path).to eq(root_path)
+      expect(page).to_not have_content(user.first_name)
+      expect(page).to have_content('SIGN IN')
+    end
   end
 
   it 'is shown an error when incorrect info is entered' do

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -2,34 +2,36 @@ require 'rails_helper'
 
 describe 'vister can create an account', :js do
   it ' visits the home page' do
-    email = 'jimbob@aol.com'
-    first_name = 'Jim'
-    last_name = 'Bob'
-    password = 'password'
+    VCR.use_cassette('github_user_repos') do
+      email = 'jimbob@aol.com'
+      first_name = 'Jim'
+      last_name = 'Bob'
+      password = 'password'
 
-    visit '/'
+      visit '/'
 
-    click_link 'Sign In'
+      click_link 'Sign In'
 
-    expect(current_path).to eq(login_path)
+      expect(current_path).to eq(login_path)
 
-    click_link 'Sign up now.'
+      click_link 'Sign up now.'
 
-    expect(current_path).to eq(new_user_path)
+      expect(current_path).to eq(new_user_path)
 
-    fill_in 'user[email]', with: email
-    fill_in 'user[first_name]', with: first_name
-    fill_in 'user[last_name]', with: last_name
-    fill_in 'user[password]', with: password
-    fill_in 'user[password_confirmation]', with: password
+      fill_in 'user[email]', with: email
+      fill_in 'user[first_name]', with: first_name
+      fill_in 'user[last_name]', with: last_name
+      fill_in 'user[password]', with: password
+      fill_in 'user[password_confirmation]', with: password
 
-    click_button 'Create Account'
+      click_button 'Create Account'
 
-    expect(current_path).to eq(dashboard_path)
+      expect(current_path).to eq(dashboard_path)
 
-    expect(page).to have_content(email)
-    expect(page).to have_content(first_name)
-    expect(page).to have_content(last_name)
-    expect(page).to_not have_content('Sign In')
+      expect(page).to have_content(email)
+      expect(page).to have_content(first_name)
+      expect(page).to have_content(last_name)
+      expect(page).to_not have_content('Sign In')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe User, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:email) }
     it { should validate_presence_of(:first_name) }
+    it { should validate_presence_of(:last_name) }
     it { should validate_presence_of(:password) }
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.configure_rspec_metadata!
   config.filter_sensitive_data('<YOUTUBE_API_KEY>') { ENV['YOUTUBE_API_KEY'] }
+  config.filter_sensitive_data('<GITHUB_ACCESS_TOKEN>') { ENV['GITHUB_ACCESS_TOKEN'] }
 end
 
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
This involved creating a GitHub service, GitHub facade, and adding a section with links to the user show page view. All tests involving the user dashboard are mocked with VCR using one cassette. Test coverage is at 78%.