### PR TITLE
Complete user account activation via email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 /node_modules
 yarn-debug.log*
 .yarn-integrity
+config/tmp

--- a/app/assets/stylesheets/junkpile.scss
+++ b/app/assets/stylesheets/junkpile.scss
@@ -332,3 +332,11 @@ div.title-bookmark {
 #tag_cloud {
   .m {font-size: 1.2em; }
 }
+
+.active {
+  color: green;
+}
+
+.inactive {
+  color: red;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   def show
     @github_facade = GithubFacade.new(current_user) if github_connection
-    @bookmark_facade = BookmarkFacade.new(current_user)
+    @bookmark_facade = BookmarkFacade.new(current_user) if current_user.user_videos.any?
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,11 +14,23 @@ class UsersController < ApplicationController
       session[:user_id] = @user.id
       flash[:success] = "Logged in as #{@user.first_name} #{@user.last_name}"
       flash[:notice] = "This account has not yet been activated. Please check your email."
+
+      UserMailer.activation(@user).deliver_later
       redirect_to dashboard_path
     else
       flash[:error] = @user.errors.full_messages.to_sentence
       render :new
     end
+  end
+
+  def update
+    if current_user.activation_token == params[:activation_token]
+      current_user.activate
+      flash[:success] = "Thank you! Your account is now activated."
+    else
+      flash[:alert] = "Your activation token is invalid, please contact support."
+    end
+    redirect_to dashboard_path
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,12 +9,14 @@ class UsersController < ApplicationController
   end
 
   def create
-    user = User.create(user_params)
-    if user.save
-      session[:user_id] = user.id
+    @user = User.create(user_params)
+    if @user.save
+      session[:user_id] = @user.id
+      flash[:success] = "Logged in as #{@user.first_name} #{@user.last_name}"
+      flash[:notice] = "This account has not yet been activated. Please check your email."
       redirect_to dashboard_path
     else
-      flash[:error] = 'Username already exists'
+      flash[:error] = @user.errors.full_messages.to_sentence
       render :new
     end
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'no-reply@brownfield-of-dreams.com'
+  default from: 'no-reply@brownfield-of-dreams-1908.herokuapp.com'
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'no-reply@brownfield-of-dreams.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,6 @@
+class UserMailer < ApplicationMailer
+  def activation(user)
+    @user = user
+    mail(to: user.email, subject: "Activate Your Account")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,11 @@ class User < ApplicationRecord
     update(active?: true)
   end
 
+  def status
+    return 'Active' if active?
+    'Inactive'
+  end
+
   def update_github(user_info)
     update(
       github_username: user_info['extra']['raw_info']['login'],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class User < ApplicationRecord
   has_many :user_videos
   has_many :videos, through: :user_videos
@@ -7,6 +9,16 @@ class User < ApplicationRecord
   validates_presence_of :first_name, :last_name
   enum role: [:default, :admin]
   has_secure_password
+
+  after_save :generate_token
+
+  def generate_token
+    self.activation_token = SecureRandom.hex(10)
+  end
+
+  def activate
+    update(active?: true)
+  end
 
   def update_github(user_info)
     update(

--- a/app/views/user_mailer/activation.html.erb
+++ b/app/views/user_mailer/activation.html.erb
@@ -1,0 +1,2 @@
+<h2>Welcome <%= @user.first_name %>! Thanks for signing up for an account at Brownfield.</h2><hr>
+<p>Click this <%= link_to "link", "http://localhost:3000/activate?activation_token=#{@user.activation_token}" %> to activate your account.</p>

--- a/app/views/user_mailer/activation.text.erb
+++ b/app/views/user_mailer/activation.text.erb
@@ -1,0 +1,3 @@
+Welcome <%= @user.first_name %>! Thanks for signing up for an account at Brownfield.
+
+Click this <%= link_to "link", "http://localhost:3000/activate?activation_token=#{@user.activation_token}" %> to activate your account.

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,11 @@
     <%= link_to 'Connect to GitHub', connect_github_path, class: 'btn btn-primary bg-teal' %>
   <% end %>
 
-  <h3>Account Details</h3>
+  <h1>Account Details</h1>
+  <h3>Account Status: <strong class="<%= current_user.status.downcase %>"><%= current_user.status %></strong></h3>
+  <p><%= 'Please follow the link sent to your email to activate your account.' if !current_user.active? %></p>
+
+  <h3>User Information</h3>
   <ul>
     <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>
     <li> <%= current_user.email%> </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,17 +14,20 @@
   </ul>
   <article>
     <h1>Bookmarked Tutorials</h1>
+    <% if !@bookmark_facade %>
+      <p>You have no bookmarked videos</p>
+    <% else %>
+      <% @bookmark_facade.bookmarks.each do |bookmark| %>
+      <article id="tutorial-<%= bookmark.tutorial_id %>">
 
-    <% @bookmark_facade.bookmarks.each do |bookmark| %>
-    <article id="tutorial-<%= bookmark.tutorial_id %>">
-
-        <h3><%= bookmark.tutorial_title %></h3>
-        <ul>
-          <% bookmark.videos.each do |video| %>
-            <li class="video"><%= link_to video.title, "/tutorials/#{bookmark.tutorial_id}?video_id=#{video.id}" %></li>
-          <% end %>
-        </ul>
-    </article>
+          <h3><%= bookmark.tutorial_title %></h3>
+          <ul>
+            <% bookmark.videos.each do |video| %>
+              <li class="bookmarked-video"><%= link_to video.title, "/tutorials/#{bookmark.tutorial_id}?video_id=#{video.id}" %></li>
+            <% end %>
+          </ul>
+      </article>
+      <% end %>
     <% end %>
 
   </article>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,17 @@ module PersonalProject
 
     # Autoload subdirectory of POROS in the models directory
     config.autoload_paths += Dir[Rails.root.join('app', 'models', 'poros')]
+
+    # Configure email sending with SendGrid SMTP
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      address:              'smtp.sendgrid.net',
+      port:                 '587',
+      domain:               'brownfield-of-dreams-1908.herokuapp.com',
+      user_name:            ENV["SENDGRID_USERNAME"],
+      password:             ENV["SENDGRID_PASSWORD"],
+      authentication:       'plain',
+      enable_starttls_auto: true
+    }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # MailCatcher settings
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   delete '/logout',                            to: 'sessions#destroy'
 
   get '/dashboard',                            to: 'users#show'
+  get '/activate',                             to: 'users#update'
   get '/about',                                to: 'about#show'
   get '/get_started',                          to: 'get_started#show'
 

--- a/db/migrate/20191210002741_add_active_to_users.rb
+++ b/db/migrate/20191210002741_add_active_to_users.rb
@@ -1,0 +1,5 @@
+class AddActiveToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :active?, :boolean, default: false
+  end
+end

--- a/db/migrate/20191210003856_add_activation_token_to_users.rb
+++ b/db/migrate/20191210003856_add_activation_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddActivationTokenToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :activation_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_05_234601) do
+ActiveRecord::Schema.define(version: 2019_12_10_003856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,8 @@ ActiveRecord::Schema.define(version: 2019_12_05_234601) do
     t.string "github_username"
     t.string "github_id"
     t.string "github_token"
+    t.boolean "active?", default: false
+    t.string "activation_token"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -145,5 +145,4 @@ RSpec.describe 'User show page', type: :feature do
       expect(page).to_not have_css(".bookmarked-video")
     end
   end
-
 end

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -124,13 +124,26 @@ RSpec.describe 'User show page', type: :feature do
       visit dashboard_path
 
       within "#tutorial-#{tutorial_1.id}" do
-        expect(page).to have_css(".video", count: 3)
+        expect(page).to have_css(".bookmarked-video", count: 3)
         expect(page).to have_link(Video.first.title)
       end
 
       within "#tutorial-#{tutorial_2.id}" do
-        expect(page).to have_css(".video", count: 4)
+        expect(page).to have_css(".bookmarked-video", count: 4)
       end
     end
   end
+
+  it "I see that I have no bookmarked videos" do
+    VCR.use_cassette('github_user_data') do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit dashboard_path
+
+      expect(page).to have_content("You have no bookmarked videos")
+      expect(page).to_not have_css(".bookmarked-video")
+    end
+  end
+
 end

--- a/spec/features/visitors/visitor_can_register_spec.rb
+++ b/spec/features/visitors/visitor_can_register_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'visitor can create an account' do
-  it ' visits the home page' do
+  it 'visits the home page' do
     VCR.use_cassette('github_user_repos') do
       email = 'jimbob@aol.com'
       first_name = 'Jim'
@@ -32,6 +32,8 @@ describe 'visitor can create an account' do
       expect(page).to have_content(first_name)
       expect(page).to have_content(last_name)
       expect(page).to_not have_content('Sign In')
+      expect(page).to have_content("Logged in as Jim Bob")
+      expect(page).to have_content("This account has not yet been activated. Please check your email.")
     end
   end
 end

--- a/spec/mailers/previews/user_preview.rb
+++ b/spec/mailers/previews/user_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user
+class UserPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe UserMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
A random ten digit hex code is sent to users via email, which is used in a link to activate the user's account.

MailCatcher and SendGrid were both configured to send (and intercept) emails. Account activation utilizes an added 'active?' column on the users table. 

Mailer testing is not yet implemented. Test coverage is at 83.4%.